### PR TITLE
ENG-1442 : Making Installation script more reliable

### DIFF
--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# Function to check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Check if required commands are available
+required_commands=("sudo" "mkdir" "touch" "exec" "tee" "date" "curl" "uname" "source" "sed" "tr" "wget" "systemctl" "chmod" "dpkg" "apt-get")
+missing_commands=()
+
+for cmd in "${required_commands[@]}"; do
+  if ! command_exists "$cmd"; then
+    missing_commands+=("$cmd")
+  fi
+done
+
+if [ ${#missing_commands[@]} -gt 0 ]; then
+  echo "Error: The following required commands are missing: ${missing_commands[*]}"
+  echo "Please install them and run the script again."
+  exit 1
+fi
+
 LOG_FILE="/var/log/mw-agent/apt-installation-$(date +%s).log"
 sudo mkdir -p /var/log/mw-agent
 sudo touch "$LOG_FILE"
@@ -34,7 +55,7 @@ EOF
 
   curl -s --location --request POST $MW_TRACKING_TARGET/api/v1/agent/tracking/$MW_API_KEY \
   --header 'Content-Type: application/json' \
-  --data-raw "$payload" > /dev/null
+  --data "$payload" > /dev/null
 }
 
 function force_continue {
@@ -148,7 +169,7 @@ sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/$MW_APT_LIST" -o Dir
 
 # Installing Agent
 echo -e "Installing Middleware Agent Binary ...\n"
-sudo apt-get install $MW_AGENT_BINARY=$MW_VERSION > /dev/null
+sudo apt-get install -y $MW_AGENT_BINARY=$MW_VERSION
 
 sudo su << EOSUDO
 


### PR DESCRIPTION
- Used --data instead of --data-raw as it is more generic across all curl versions

- Added prequisite check at the start of script execution

- DEB script was getting stuck sometimes because it was waiting for client response [Y|n] , and `> dev/null` was not allowing this to show