### PR TITLE
Remove extra_metadata_labels from otel-config-daemonset.yaml

### DIFF
--- a/scripts/otel-config-daemonset.yaml
+++ b/scripts/otel-config-daemonset.yaml
@@ -91,7 +91,6 @@ receivers:
     insecure_skip_verify: true
     k8s_api_config:
       auth_type: serviceAccount
-    extra_metadata_labels: [container.id, k8s.volume.type]
   hostmetrics:
     collection_interval: 5s
     scrapers:


### PR DESCRIPTION
Remove `extra_metadata_labels` from otel-config-daemonset.yaml` to reduce audit logs.