### PR TITLE
Hotfix to first remove the agent and then re-install for rpm script

### DIFF
--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -186,9 +186,17 @@ echo -e "\nThe host agent will monitor all '.log' files inside your /var/log dir
 echo "yum.middleware.io/$MW_DETECTED_ARCH/Packages/$RPM_FILE"
 curl -L -q -s -o "$RPM_FILE" yum.middleware.io/"$MW_DETECTED_ARCH"/Packages/"$RPM_FILE" $skip_certificate_check
 
-echo -e "Installing Middleware Agent Service ...\n"
+# Remove mw-agent if present
+if rpm -q mw-agent &>/dev/null; then
+  echo "Removing existing Middleware Agent..."
+  if ! sudo -E rpm -e mw-agent; then
+    echo "Error: Failed to remove existing Middleware Agent."
+    exit 1
+  fi
+fi
 
-# Check for errors
+# Install the new package
+echo "Installing Middleware Agent..."
 if ! sudo -E rpm -U "$RPM_FILE"; then
   echo "Error: Failed to install Middleware Agent."
   exit 1


### PR DESCRIPTION
This is needed in case the agent is already installed. This avoids failures in case of agent is installed through infra tools (terraform, beanstalk etc)