### PR TITLE
AGE-101: Removed logging exporter from default k8s configs

### DIFF
--- a/configyamls/all/otel-config.yaml
+++ b/configyamls/all/otel-config.yaml
@@ -1,6 +1,4 @@
 exporters:
-  logging:
-    loglevel: debug
   otlp/2:
     endpoint: ${MW_TARGET}
     headers:

--- a/configyamls/nodocker/otel-config.yaml
+++ b/configyamls/nodocker/otel-config.yaml
@@ -100,8 +100,6 @@ processors:
         timeout: 5s
         override: false
 exporters:
-  logging:
-    loglevel: debug
   otlp/2:
     endpoint: ${MW_TARGET}
     headers:

--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -348,8 +348,6 @@ processors:
     override: false
 
 exporters:
-  logging:
-    loglevel: info
   otlp/2:
     endpoint: ${MW_TARGET}
     timeout: 60s

--- a/scripts/mw-kube-agent-log.yaml
+++ b/scripts/mw-kube-agent-log.yaml
@@ -40,8 +40,6 @@ data:
           http:
             endpoint: 0.0.0.0:9320
     exporters:
-      logging:
-        loglevel: warn
       otlp:
         endpoint: ${TARGET}
     processors:

--- a/scripts/otel-config-daemonset.yaml
+++ b/scripts/otel-config-daemonset.yaml
@@ -141,8 +141,6 @@ receivers:
       http:
         endpoint: 0.0.0.0:9320
 exporters:
-  logging:
-    loglevel: fatal
   otlp:
     endpoint: ${MW_TARGET}
 processors:
@@ -324,7 +322,7 @@ service:
       metrics/kubeletstats:
         receivers: [ kubeletstats ]
         processors: [ resourcedetection, resource, k8sattributes, resource/cluster, batch, batch/2]
-        exporters: [ otlp, logging ]
+        exporters: [ otlp ]
       metrics/hostmetrics:
         receivers: [ hostmetrics ]
         processors: [ resourcedetection, resource, resource/hostmetrics, resource/cluster, k8sattributes, batch, batch/2]

--- a/scripts/otel-config-deployment.yaml
+++ b/scripts/otel-config-deployment.yaml
@@ -26,8 +26,6 @@ receivers:
       http:
         endpoint: 0.0.0.0:9320
 exporters:
-  logging:
-    loglevel: warn
   otlp:
     endpoint: ${MW_TARGET}
 processors:


### PR DESCRIPTION
When `ingestion-rules` API fail for k8s agent, the default configs consists `logging`, which is not supported for new agents.
Therefore, removing them from default configs.