### PR TITLE
AGE-230 : Updating docker image tag for configupdater

### DIFF
--- a/manifests/mw-kube-agent/configupdater.yaml
+++ b/manifests/mw-kube-agent/configupdater.yaml
@@ -28,7 +28,7 @@ spec:
               value:  "NAMESPACE_VALUE"
             - name: MW_CONFIG_CHECK_INTERVAL
               value: MW_CONFIG_CHECK_INTERVAL_VALUE
-          image: ghcr.io/middleware-labs/mw-kube-agent-config-updater:local
+          image: ghcr.io/middleware-labs/mw-kube-agent-config-updater:MW_VERSION_VALUE
           imagePullPolicy: IfNotPresent
           name: mw-kube-agent-config-updater
           securityContext:


### PR DESCRIPTION
As the `local` tag is currently static.
`ingestion-rules` API is always getting `agent_version=1.14.0` when a user install k8s agent via bash script

Fixed it via using MW_VERSION_VALUE, which will be replace via bash script