### PR TITLE
Fixing agent tracking curl issue 

### DIFF
--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -56,7 +56,7 @@ function send_logs {
     "status": "ok",
     "message": "$message",
     "host_id": "$host_id",
-    "script_logs": "$(sed 's/$/\\n/' "$LOG_FILE" | tr -d '\n' | sed 's/"/\\\"/g')"
+    "script_logs": "$(sed 's/$/\\n/' "$LOG_FILE" | tr -d '\r\n' | sed 's/"/\\\"/g')"
   }
 }
 EOF


### PR DESCRIPTION
{"error":"invalid character '\\r' in string literal"}
Currently.. if script_logs are having any tabs then `installed` and `failed` events are not getting recorded. Curl request fails

trimming `\r` to avoid this issue