### PR TITLE
Otel injector moved to otel packaging

### DIFF
--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -111,15 +111,17 @@ get_latest_mw_agent_version() {
   echo "$latest_version"
 }
 
-# DEB/RPM packages for the OpenTelemetry Injector are published from
-# open-telemetry/opentelemetry-packaging (which has its own version scheme).
-# open-telemetry/opentelemetry-injector stopped shipping packages after v0.9.0
-# and now releases only the raw libotelinject_*.so library.
-# Returns an empty string if the latest version cannot be resolved; callers
-# treat that as "skip the injector" rather than aborting the install.
+# Returns the latest STABLE (non-prerelease, non-draft) OpenTelemetry Injector
+# release from open-telemetry/opentelemetry-packaging, or an empty string when
+# there are none yet. The caller falls back to a pinned known-good version.
+# Newer DEB/RPM packages are published from opentelemetry-packaging (its own
+# version scheme); the legacy open-telemetry/opentelemetry-injector repo shipped
+# packages up to v0.9.2 and from v0.10.0 releases only the raw libotelinject_*.so.
 get_latest_otel_injector_version() {
   repo="open-telemetry/opentelemetry-packaging"
 
+  # /releases/latest returns the newest stable release, or 404 (empty) when the
+  # repo has only pre-releases, as is currently the case.
   latest_version=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
   if [ "$latest_version" = "null" ]; then
@@ -243,15 +245,24 @@ if [ "${MW_ENABLE_INJECTOR}" = "" ]; then
 fi
 export MW_ENABLE_INJECTOR
 
-# Injector download source. With no pinned version we install the latest
-# package from open-telemetry/opentelemetry-packaging. A user-pinned
-# OTEL_INJECTOR_VERSION is treated as a legacy version from the
-# open-telemetry/opentelemetry-injector repo (packages up to v0.9.0).
-OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
-if [ "${OTEL_INJECTOR_VERSION}" = "" ]; then
-  OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
-else
+# Injector download source (version + repo are resolved together):
+#   - User-pinned OTEL_INJECTOR_VERSION: fetched from the legacy
+#     open-telemetry/opentelemetry-injector repo (packages up to v0.9.2 live there).
+#   - No pin: prefer the latest stable release from opentelemetry-packaging;
+#     while that repo has only a pre-release, fall back to the last known-good
+#     stable (v0.9.2) from the legacy injector repo.
+OTEL_INJECTOR_FALLBACK_VERSION="v0.9.2"
+OTEL_INJECTOR_FALLBACK_REPO="open-telemetry/opentelemetry-injector"
+if [ "${OTEL_INJECTOR_VERSION}" != "" ]; then
   OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-injector"
+else
+  OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
+  if [ -n "${OTEL_INJECTOR_VERSION}" ]; then
+    OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
+  else
+    OTEL_INJECTOR_VERSION="${OTEL_INJECTOR_FALLBACK_VERSION}"
+    OTEL_INJECTOR_REPO="${OTEL_INJECTOR_FALLBACK_REPO}"
+  fi
 fi
 export OTEL_INJECTOR_VERSION
 export OTEL_INJECTOR_REPO
@@ -322,11 +333,11 @@ echo -e "Middleware Agent installation completed successfully.\n"
 if [ "${MW_ENABLE_INJECTOR}" = true ]; then
   if ! (
     if [ -z "${OTEL_INJECTOR_VERSION}" ]; then
-      log_error "Could not determine the OpenTelemetry Injector version to install."
+      echo "Error: Could not determine the OpenTelemetry Injector version to install."
       exit 1
     fi
 
-    log_info "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION}..."
+    echo -e "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION} ...\n"
 
     # Map detected arch to the arch string used in injector release filenames
     OTEL_INJECTOR_ARCH=""
@@ -335,7 +346,7 @@ if [ "${MW_ENABLE_INJECTOR}" = true ]; then
     elif [[ $MW_APT_LIST_ARCH == "amd64" ]]; then
       OTEL_INJECTOR_ARCH="amd64"
     else
-      log_warn "Unsupported architecture '${MW_DETECTED_ARCH}' for OTel Injector. Skipping."
+      echo "Warning: Unsupported architecture '${MW_DETECTED_ARCH}' for OTel Injector. Skipping."
       exit 1
     fi
 
@@ -346,27 +357,26 @@ if [ "${MW_ENABLE_INJECTOR}" = true ]; then
     OTEL_INJECTOR_URL="https://github.com/${OTEL_INJECTOR_REPO}/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_DEB}"
     OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_DEB}"
 
-    log_info "Downloading ${OTEL_INJECTOR_URL}..."
+    echo "Downloading ${OTEL_INJECTOR_URL} ..."
     if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
-      log_error "Failed to download OpenTelemetry Injector package."
-      log_error "URL: ${OTEL_INJECTOR_URL}"
+      echo "Error: Failed to download OpenTelemetry Injector package."
+      echo "URL: ${OTEL_INJECTOR_URL}"
       rm -f "$OTEL_INJECTOR_TMP"
       exit 1
     fi
-    log_ok "Downloaded ${OTEL_INJECTOR_DEB}."
+    echo "Downloaded ${OTEL_INJECTOR_DEB}."
 
-    log_info "Installing OpenTelemetry Injector package..."
+    echo "Installing OpenTelemetry Injector package ..."
     if ! sudo dpkg -i "$OTEL_INJECTOR_TMP"; then
-      log_error "Failed to install OpenTelemetry Injector package."
+      echo "Error: Failed to install OpenTelemetry Injector package."
       rm -f "$OTEL_INJECTOR_TMP"
       exit 1
     fi
 
     rm -f "$OTEL_INJECTOR_TMP"
 
-    log_ok "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully."
+    echo -e "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully.\n"
 
-    echo ""
     echo "================================================================="
     echo "  OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} (${MW_DETECTED_ARCH}) installed successfully"
     echo "================================================================="
@@ -375,7 +385,7 @@ if [ "${MW_ENABLE_INJECTOR}" = true ]; then
     echo "  Version:       ${OTEL_INJECTOR_VERSION}"
     echo ""
   ); then
-    log_warn "OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected."
+    echo -e "Warning: OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected.\n"
   fi
 else
   echo -e "OTel Injector installation skipped (MW_ENABLE_INJECTOR=${MW_ENABLE_INJECTOR}).\n"

--- a/scripts/deb-install.sh
+++ b/scripts/deb-install.sh
@@ -111,13 +111,19 @@ get_latest_mw_agent_version() {
   echo "$latest_version"
 }
 
+# DEB/RPM packages for the OpenTelemetry Injector are published from
+# open-telemetry/opentelemetry-packaging (which has its own version scheme).
+# open-telemetry/opentelemetry-injector stopped shipping packages after v0.9.0
+# and now releases only the raw libotelinject_*.so library.
+# Returns an empty string if the latest version cannot be resolved; callers
+# treat that as "skip the injector" rather than aborting the install.
 get_latest_otel_injector_version() {
-  repo="open-telemetry/opentelemetry-injector"
+  repo="open-telemetry/opentelemetry-packaging"
 
   latest_version=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
-  if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
-    latest_version="v0.1.0"
+  if [ "$latest_version" = "null" ]; then
+    latest_version=""
   fi
 
   echo "$latest_version"
@@ -237,10 +243,18 @@ if [ "${MW_ENABLE_INJECTOR}" = "" ]; then
 fi
 export MW_ENABLE_INJECTOR
 
+# Injector download source. With no pinned version we install the latest
+# package from open-telemetry/opentelemetry-packaging. A user-pinned
+# OTEL_INJECTOR_VERSION is treated as a legacy version from the
+# open-telemetry/opentelemetry-injector repo (packages up to v0.9.0).
+OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
 if [ "${OTEL_INJECTOR_VERSION}" = "" ]; then
   OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
+else
+  OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-injector"
 fi
 export OTEL_INJECTOR_VERSION
+export OTEL_INJECTOR_REPO
 
 # OBI Agent defaults
 if [ "${MW_ENABLE_OBI}" = "" ]; then
@@ -301,45 +315,68 @@ echo -e "Middleware Agent installation completed successfully.\n"
 
 # -------------------------------------------------------
 # OTel Injector Installation
+#
+# Best-effort add-on: if the injector cannot be resolved, downloaded, or
+# installed we warn and continue so that core agent monitoring is unaffected.
 # -------------------------------------------------------
 if [ "${MW_ENABLE_INJECTOR}" = true ]; then
-  echo -e "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION} ...\n"
+  if ! (
+    if [ -z "${OTEL_INJECTOR_VERSION}" ]; then
+      log_error "Could not determine the OpenTelemetry Injector version to install."
+      exit 1
+    fi
 
-  # Map detected arch to the arch string used in injector release filenames
-  OTEL_INJECTOR_ARCH=""
-  if [[ $MW_APT_LIST_ARCH == "arm64" ]]; then
-    OTEL_INJECTOR_ARCH="arm64"
-  elif [[ $MW_APT_LIST_ARCH == "amd64" ]]; then
-    OTEL_INJECTOR_ARCH="amd64"
-  else
-    echo "Warning: Unsupported architecture '$MW_DETECTED_ARCH' for OTel Injector. Skipping."
-    exit 0
-  fi
+    log_info "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION}..."
 
-  # Strip leading 'v' from version for the filename (e.g. v0.1.0 -> 0.1.0)
-  OTEL_INJECTOR_VERSION_STRIPPED="${OTEL_INJECTOR_VERSION#v}"
+    # Map detected arch to the arch string used in injector release filenames
+    OTEL_INJECTOR_ARCH=""
+    if [[ $MW_APT_LIST_ARCH == "arm64" ]]; then
+      OTEL_INJECTOR_ARCH="arm64"
+    elif [[ $MW_APT_LIST_ARCH == "amd64" ]]; then
+      OTEL_INJECTOR_ARCH="amd64"
+    else
+      log_warn "Unsupported architecture '${MW_DETECTED_ARCH}' for OTel Injector. Skipping."
+      exit 1
+    fi
 
-  OTEL_INJECTOR_DEB="opentelemetry-injector_${OTEL_INJECTOR_VERSION_STRIPPED}_${OTEL_INJECTOR_ARCH}.deb"
-  OTEL_INJECTOR_URL="https://github.com/open-telemetry/opentelemetry-injector/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_DEB}"
-  OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_DEB}"
+    # Strip leading 'v' from version for the filename (e.g. v0.1.0 -> 0.1.0)
+    OTEL_INJECTOR_VERSION_STRIPPED="${OTEL_INJECTOR_VERSION#v}"
 
-  echo "Downloading ${OTEL_INJECTOR_URL} ..."
-  if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
-    echo "Error: Failed to download OpenTelemetry Injector package."
-    echo "URL: ${OTEL_INJECTOR_URL}"
-    exit 1
-  fi
+    OTEL_INJECTOR_DEB="opentelemetry-injector_${OTEL_INJECTOR_VERSION_STRIPPED}_${OTEL_INJECTOR_ARCH}.deb"
+    OTEL_INJECTOR_URL="https://github.com/${OTEL_INJECTOR_REPO}/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_DEB}"
+    OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_DEB}"
 
-  echo "Installing OpenTelemetry Injector package ..."
-  if ! sudo dpkg -i "$OTEL_INJECTOR_TMP"; then
-    echo "Error: Failed to install OpenTelemetry Injector package."
+    log_info "Downloading ${OTEL_INJECTOR_URL}..."
+    if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
+      log_error "Failed to download OpenTelemetry Injector package."
+      log_error "URL: ${OTEL_INJECTOR_URL}"
+      rm -f "$OTEL_INJECTOR_TMP"
+      exit 1
+    fi
+    log_ok "Downloaded ${OTEL_INJECTOR_DEB}."
+
+    log_info "Installing OpenTelemetry Injector package..."
+    if ! sudo dpkg -i "$OTEL_INJECTOR_TMP"; then
+      log_error "Failed to install OpenTelemetry Injector package."
+      rm -f "$OTEL_INJECTOR_TMP"
+      exit 1
+    fi
+
     rm -f "$OTEL_INJECTOR_TMP"
-    exit 1
+
+    log_ok "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully."
+
+    echo ""
+    echo "================================================================="
+    echo "  OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} (${MW_DETECTED_ARCH}) installed successfully"
+    echo "================================================================="
+    echo ""
+    echo "  Package:       ${OTEL_INJECTOR_DEB}"
+    echo "  Version:       ${OTEL_INJECTOR_VERSION}"
+    echo ""
+  ); then
+    log_warn "OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected."
   fi
-
-  rm -f "$OTEL_INJECTOR_TMP"
-
-  echo -e "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully.\n"
 else
   echo -e "OTel Injector installation skipped (MW_ENABLE_INJECTOR=${MW_ENABLE_INJECTOR}).\n"
 fi

--- a/scripts/deb_install_injector.sh
+++ b/scripts/deb_install_injector.sh
@@ -139,6 +139,7 @@ echo -e "\nInstalling Middleware Agent version ${MW_VERSION} on hostname $(hostn
 
 # Check if /etc/os-release file exists
 if [ -f /etc/os-release ]; then
+  # shellcheck source=/dev/null
   source /etc/os-release
   case "$ID" in
     debian|ubuntu)

--- a/scripts/deb_install_injector.sh
+++ b/scripts/deb_install_injector.sh
@@ -99,15 +99,17 @@ get_latest_mw_agent_version() {
   echo "$latest_version"
 }
 
-# DEB/RPM packages for the OpenTelemetry Injector are published from
-# open-telemetry/opentelemetry-packaging (which has its own version scheme).
-# open-telemetry/opentelemetry-injector stopped shipping packages after v0.9.0
-# and now releases only the raw libotelinject_*.so library.
-# Returns an empty string if the latest version cannot be resolved; callers
-# treat that as "skip the injector" rather than aborting the install.
+# Returns the latest STABLE (non-prerelease, non-draft) OpenTelemetry Injector
+# release from open-telemetry/opentelemetry-packaging, or an empty string when
+# there are none yet. The caller falls back to a pinned known-good version.
+# Newer DEB/RPM packages are published from opentelemetry-packaging (its own
+# version scheme); the legacy open-telemetry/opentelemetry-injector repo shipped
+# packages up to v0.9.2 and from v0.10.0 releases only the raw libotelinject_*.so.
 get_latest_otel_injector_version() {
   repo="open-telemetry/opentelemetry-packaging"
 
+  # /releases/latest returns the newest stable release, or 404 (empty) when the
+  # repo has only pre-releases, as is currently the case.
   latest_version=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
   if [ "$latest_version" = "null" ]; then
@@ -231,15 +233,24 @@ if [ "${MW_ENABLE_INJECTOR}" = "" ]; then
 fi
 export MW_ENABLE_INJECTOR
 
-# Injector download source. With no pinned version we install the latest
-# package from open-telemetry/opentelemetry-packaging. A user-pinned
-# OTEL_INJECTOR_VERSION is treated as a legacy version from the
-# open-telemetry/opentelemetry-injector repo (packages up to v0.9.0).
-OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
-if [ "${OTEL_INJECTOR_VERSION}" = "" ]; then
-  OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
-else
+# Injector download source (version + repo are resolved together):
+#   - User-pinned OTEL_INJECTOR_VERSION: fetched from the legacy
+#     open-telemetry/opentelemetry-injector repo (packages up to v0.9.2 live there).
+#   - No pin: prefer the latest stable release from opentelemetry-packaging;
+#     while that repo has only a pre-release, fall back to the last known-good
+#     stable (v0.9.2) from the legacy injector repo.
+OTEL_INJECTOR_FALLBACK_VERSION="v0.9.2"
+OTEL_INJECTOR_FALLBACK_REPO="open-telemetry/opentelemetry-injector"
+if [ "${OTEL_INJECTOR_VERSION}" != "" ]; then
   OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-injector"
+else
+  OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
+  if [ -n "${OTEL_INJECTOR_VERSION}" ]; then
+    OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
+  else
+    OTEL_INJECTOR_VERSION="${OTEL_INJECTOR_FALLBACK_VERSION}"
+    OTEL_INJECTOR_REPO="${OTEL_INJECTOR_FALLBACK_REPO}"
+  fi
 fi
 export OTEL_INJECTOR_VERSION
 export OTEL_INJECTOR_REPO

--- a/scripts/deb_install_injector.sh
+++ b/scripts/deb_install_injector.sh
@@ -99,13 +99,19 @@ get_latest_mw_agent_version() {
   echo "$latest_version"
 }
 
+# DEB/RPM packages for the OpenTelemetry Injector are published from
+# open-telemetry/opentelemetry-packaging (which has its own version scheme).
+# open-telemetry/opentelemetry-injector stopped shipping packages after v0.9.0
+# and now releases only the raw libotelinject_*.so library.
+# Returns an empty string if the latest version cannot be resolved; callers
+# treat that as "skip the injector" rather than aborting the install.
 get_latest_otel_injector_version() {
-  repo="open-telemetry/opentelemetry-injector"
+  repo="open-telemetry/opentelemetry-packaging"
 
   latest_version=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
-  if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
-    latest_version="v0.1.0"
+  if [ "$latest_version" = "null" ]; then
+    latest_version=""
   fi
 
   echo "$latest_version"
@@ -224,10 +230,18 @@ if [ "${MW_ENABLE_INJECTOR}" = "" ]; then
 fi
 export MW_ENABLE_INJECTOR
 
+# Injector download source. With no pinned version we install the latest
+# package from open-telemetry/opentelemetry-packaging. A user-pinned
+# OTEL_INJECTOR_VERSION is treated as a legacy version from the
+# open-telemetry/opentelemetry-injector repo (packages up to v0.9.0).
+OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
 if [ "${OTEL_INJECTOR_VERSION}" = "" ]; then
   OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
+else
+  OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-injector"
 fi
 export OTEL_INJECTOR_VERSION
+export OTEL_INJECTOR_REPO
 
 # OBI Agent defaults
 if [ "${MW_ENABLE_OBI}" = "" ]; then
@@ -288,45 +302,58 @@ echo -e "Middleware Agent installation completed successfully.\n"
 
 # -------------------------------------------------------
 # OTel Injector Installation
+#
+# Best-effort add-on: if the injector cannot be resolved, downloaded, or
+# installed we warn and continue so that core agent monitoring is unaffected.
 # -------------------------------------------------------
 if [ "${MW_ENABLE_INJECTOR}" = true ]; then
-  echo -e "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION} ...\n"
+  if ! (
+    if [ -z "${OTEL_INJECTOR_VERSION}" ]; then
+      echo "Error: Could not determine the OpenTelemetry Injector version to install."
+      exit 1
+    fi
 
-  # Map detected arch to the arch string used in injector release filenames
-  OTEL_INJECTOR_ARCH=""
-  if [[ $MW_APT_LIST_ARCH == "arm64" ]]; then
-    OTEL_INJECTOR_ARCH="arm64"
-  elif [[ $MW_APT_LIST_ARCH == "amd64" ]]; then
-    OTEL_INJECTOR_ARCH="amd64"
-  else
-    echo "Warning: Unsupported architecture '$MW_DETECTED_ARCH' for OTel Injector. Skipping."
-    exit 0
-  fi
+    echo -e "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION} ...\n"
 
-  # Strip leading 'v' from version for the filename (e.g. v0.1.0 -> 0.1.0)
-  OTEL_INJECTOR_VERSION_STRIPPED="${OTEL_INJECTOR_VERSION#v}"
+    # Map detected arch to the arch string used in injector release filenames
+    OTEL_INJECTOR_ARCH=""
+    if [[ $MW_APT_LIST_ARCH == "arm64" ]]; then
+      OTEL_INJECTOR_ARCH="arm64"
+    elif [[ $MW_APT_LIST_ARCH == "amd64" ]]; then
+      OTEL_INJECTOR_ARCH="amd64"
+    else
+      echo "Warning: Unsupported architecture '$MW_DETECTED_ARCH' for OTel Injector. Skipping."
+      exit 1
+    fi
 
-  OTEL_INJECTOR_DEB="opentelemetry-injector_${OTEL_INJECTOR_VERSION_STRIPPED}_${OTEL_INJECTOR_ARCH}.deb"
-  OTEL_INJECTOR_URL="https://github.com/open-telemetry/opentelemetry-injector/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_DEB}"
-  OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_DEB}"
+    # Strip leading 'v' from version for the filename (e.g. v0.1.0 -> 0.1.0)
+    OTEL_INJECTOR_VERSION_STRIPPED="${OTEL_INJECTOR_VERSION#v}"
 
-  echo "Downloading ${OTEL_INJECTOR_URL} ..."
-  if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
-    echo "Error: Failed to download OpenTelemetry Injector package."
-    echo "URL: ${OTEL_INJECTOR_URL}"
-    exit 1
-  fi
+    OTEL_INJECTOR_DEB="opentelemetry-injector_${OTEL_INJECTOR_VERSION_STRIPPED}_${OTEL_INJECTOR_ARCH}.deb"
+    OTEL_INJECTOR_URL="https://github.com/${OTEL_INJECTOR_REPO}/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_DEB}"
+    OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_DEB}"
 
-  echo "Installing OpenTelemetry Injector package ..."
-  if ! sudo dpkg -i "$OTEL_INJECTOR_TMP"; then
-    echo "Error: Failed to install OpenTelemetry Injector package."
+    echo "Downloading ${OTEL_INJECTOR_URL} ..."
+    if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
+      echo "Error: Failed to download OpenTelemetry Injector package."
+      echo "URL: ${OTEL_INJECTOR_URL}"
+      rm -f "$OTEL_INJECTOR_TMP"
+      exit 1
+    fi
+
+    echo "Installing OpenTelemetry Injector package ..."
+    if ! sudo dpkg -i "$OTEL_INJECTOR_TMP"; then
+      echo "Error: Failed to install OpenTelemetry Injector package."
+      rm -f "$OTEL_INJECTOR_TMP"
+      exit 1
+    fi
+
     rm -f "$OTEL_INJECTOR_TMP"
-    exit 1
+
+    echo -e "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully.\n"
+  ); then
+    echo -e "Warning: OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected.\n"
   fi
-
-  rm -f "$OTEL_INJECTOR_TMP"
-
-  echo -e "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully.\n"
 else
   echo -e "OTel Injector installation skipped (MW_ENABLE_INJECTOR=${MW_ENABLE_INJECTOR}).\n"
 fi

--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -111,13 +111,19 @@ get_latest_mw_agent_version() {
   echo "$latest_version"
 }
 
+# DEB/RPM packages for the OpenTelemetry Injector are published from
+# open-telemetry/opentelemetry-packaging (which has its own version scheme).
+# open-telemetry/opentelemetry-injector stopped shipping packages after v0.9.0
+# and now releases only the raw libotelinject_*.so library.
+# Returns an empty string if the latest version cannot be resolved; callers
+# treat that as "skip the injector" rather than aborting the install.
 get_latest_otel_injector_version() {
-  repo="open-telemetry/opentelemetry-injector"
+  repo="open-telemetry/opentelemetry-packaging"
 
   latest_version=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
-  if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
-    latest_version="v0.1.0"
+  if [ "$latest_version" = "null" ]; then
+    latest_version=""
   fi
 
   echo "$latest_version"
@@ -220,10 +226,18 @@ if [ "${MW_ENABLE_INJECTOR}" = "" ]; then
 fi
 export MW_ENABLE_INJECTOR
 
+# Injector download source. With no pinned version we install the latest
+# package from open-telemetry/opentelemetry-packaging. A user-pinned
+# OTEL_INJECTOR_VERSION is treated as a legacy version from the
+# open-telemetry/opentelemetry-injector repo (packages up to v0.9.0).
+OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
 if [ "${OTEL_INJECTOR_VERSION}" = "" ]; then
   OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
+else
+  OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-injector"
 fi
 export OTEL_INJECTOR_VERSION
+export OTEL_INJECTOR_REPO
 
 # OBI Agent defaults
 if [ "${MW_ENABLE_OBI}" = "" ]; then
@@ -289,45 +303,68 @@ echo -e "Middleware Agent installation completed successfully.\n"
 
 # -------------------------------------------------------
 # OTel Injector Installation
+#
+# Best-effort add-on: if the injector cannot be resolved, downloaded, or
+# installed we warn and continue so that core agent monitoring is unaffected.
 # -------------------------------------------------------
 if [ "${MW_ENABLE_INJECTOR}" = true ]; then
-  echo -e "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION} ...\n"
+  if ! (
+    if [ -z "${OTEL_INJECTOR_VERSION}" ]; then
+      log_error "Could not determine the OpenTelemetry Injector version to install."
+      exit 1
+    fi
 
-  # Map uname -m arch to the arch string used in injector release filenames
-  OTEL_INJECTOR_ARCH=""
-  if [[ $MW_DETECTED_ARCH == "aarch64" || $MW_DETECTED_ARCH == "arm64" ]]; then
-    OTEL_INJECTOR_ARCH="aarch64"
-  elif [[ $MW_DETECTED_ARCH == "x86_64" ]]; then
-    OTEL_INJECTOR_ARCH="x86_64"
-  else
-    echo "Warning: Unsupported architecture '$MW_DETECTED_ARCH' for OTel Injector. Skipping."
-    exit 0
-  fi
+    log_info "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION}..."
 
-  # Strip leading 'v' from version for the filename (e.g. v0.1.0 -> 0.1.0)
-  OTEL_INJECTOR_VERSION_STRIPPED="${OTEL_INJECTOR_VERSION#v}"
+    # Map uname -m arch to the arch string used in injector release filenames
+    OTEL_INJECTOR_ARCH=""
+    if [[ $MW_DETECTED_ARCH == "aarch64" || $MW_DETECTED_ARCH == "arm64" ]]; then
+      OTEL_INJECTOR_ARCH="aarch64"
+    elif [[ $MW_DETECTED_ARCH == "x86_64" ]]; then
+      OTEL_INJECTOR_ARCH="x86_64"
+    else
+      log_warn "Unsupported architecture '${MW_DETECTED_ARCH}' for OTel Injector. Skipping."
+      exit 1
+    fi
 
-  OTEL_INJECTOR_RPM="opentelemetry-injector-${OTEL_INJECTOR_VERSION_STRIPPED}-1.${OTEL_INJECTOR_ARCH}.rpm"
-  OTEL_INJECTOR_URL="https://github.com/open-telemetry/opentelemetry-injector/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_RPM}"
-  OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_RPM}"
+    # Strip leading 'v' from version for the filename (e.g. v0.1.0 -> 0.1.0)
+    OTEL_INJECTOR_VERSION_STRIPPED="${OTEL_INJECTOR_VERSION#v}"
 
-  echo "Downloading ${OTEL_INJECTOR_URL} ..."
-  if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
-    echo "Error: Failed to download OpenTelemetry Injector package."
-    echo "URL: ${OTEL_INJECTOR_URL}"
-    exit 1
-  fi
+    OTEL_INJECTOR_RPM="opentelemetry-injector-${OTEL_INJECTOR_VERSION_STRIPPED}-1.${OTEL_INJECTOR_ARCH}.rpm"
+    OTEL_INJECTOR_URL="https://github.com/${OTEL_INJECTOR_REPO}/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_RPM}"
+    OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_RPM}"
 
-  echo "Installing OpenTelemetry Injector package ..."
-  if ! sudo rpm -U --replacepkgs "$OTEL_INJECTOR_TMP"; then
-    echo "Error: Failed to install OpenTelemetry Injector package."
+    log_info "Downloading ${OTEL_INJECTOR_URL}..."
+    if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
+      log_error "Failed to download OpenTelemetry Injector package."
+      log_error "URL: ${OTEL_INJECTOR_URL}"
+      rm -f "$OTEL_INJECTOR_TMP"
+      exit 1
+    fi
+    log_ok "Downloaded ${OTEL_INJECTOR_RPM}."
+
+    log_info "Installing OpenTelemetry Injector package..."
+    if ! sudo rpm -U --replacepkgs "$OTEL_INJECTOR_TMP"; then
+      log_error "Failed to install OpenTelemetry Injector package."
+      rm -f "$OTEL_INJECTOR_TMP"
+      exit 1
+    fi
+
     rm -f "$OTEL_INJECTOR_TMP"
-    exit 1
+
+    log_ok "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully."
+
+    echo ""
+    echo "================================================================="
+    echo "  OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} (${MW_DETECTED_ARCH}) installed successfully"
+    echo "================================================================="
+    echo ""
+    echo "  Package:       ${OTEL_INJECTOR_RPM}"
+    echo "  Version:       ${OTEL_INJECTOR_VERSION}"
+    echo ""
+  ); then
+    log_warn "OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected."
   fi
-
-  rm -f "$OTEL_INJECTOR_TMP"
-
-  echo -e "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully.\n"
 else
   echo -e "OTel Injector installation skipped (MW_ENABLE_INJECTOR=${MW_ENABLE_INJECTOR}).\n"
 fi

--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -111,15 +111,17 @@ get_latest_mw_agent_version() {
   echo "$latest_version"
 }
 
-# DEB/RPM packages for the OpenTelemetry Injector are published from
-# open-telemetry/opentelemetry-packaging (which has its own version scheme).
-# open-telemetry/opentelemetry-injector stopped shipping packages after v0.9.0
-# and now releases only the raw libotelinject_*.so library.
-# Returns an empty string if the latest version cannot be resolved; callers
-# treat that as "skip the injector" rather than aborting the install.
+# Returns the latest STABLE (non-prerelease, non-draft) OpenTelemetry Injector
+# release from open-telemetry/opentelemetry-packaging, or an empty string when
+# there are none yet. The caller falls back to a pinned known-good version.
+# Newer DEB/RPM packages are published from opentelemetry-packaging (its own
+# version scheme); the legacy open-telemetry/opentelemetry-injector repo shipped
+# packages up to v0.9.2 and from v0.10.0 releases only the raw libotelinject_*.so.
 get_latest_otel_injector_version() {
   repo="open-telemetry/opentelemetry-packaging"
 
+  # /releases/latest returns the newest stable release, or 404 (empty) when the
+  # repo has only pre-releases, as is currently the case.
   latest_version=$(curl --silent "https://api.github.com/repos/$repo/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
   if [ "$latest_version" = "null" ]; then
@@ -227,15 +229,24 @@ if [ "${MW_ENABLE_INJECTOR}" = "" ]; then
 fi
 export MW_ENABLE_INJECTOR
 
-# Injector download source. With no pinned version we install the latest
-# package from open-telemetry/opentelemetry-packaging. A user-pinned
-# OTEL_INJECTOR_VERSION is treated as a legacy version from the
-# open-telemetry/opentelemetry-injector repo (packages up to v0.9.0).
-OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
-if [ "${OTEL_INJECTOR_VERSION}" = "" ]; then
-  OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
-else
+# Injector download source (version + repo are resolved together):
+#   - User-pinned OTEL_INJECTOR_VERSION: fetched from the legacy
+#     open-telemetry/opentelemetry-injector repo (packages up to v0.9.2 live there).
+#   - No pin: prefer the latest stable release from opentelemetry-packaging;
+#     while that repo has only a pre-release, fall back to the last known-good
+#     stable (v0.9.2) from the legacy injector repo.
+OTEL_INJECTOR_FALLBACK_VERSION="v0.9.2"
+OTEL_INJECTOR_FALLBACK_REPO="open-telemetry/opentelemetry-injector"
+if [ "${OTEL_INJECTOR_VERSION}" != "" ]; then
   OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-injector"
+else
+  OTEL_INJECTOR_VERSION=$(get_latest_otel_injector_version)
+  if [ -n "${OTEL_INJECTOR_VERSION}" ]; then
+    OTEL_INJECTOR_REPO="open-telemetry/opentelemetry-packaging"
+  else
+    OTEL_INJECTOR_VERSION="${OTEL_INJECTOR_FALLBACK_VERSION}"
+    OTEL_INJECTOR_REPO="${OTEL_INJECTOR_FALLBACK_REPO}"
+  fi
 fi
 export OTEL_INJECTOR_VERSION
 export OTEL_INJECTOR_REPO
@@ -311,11 +322,11 @@ echo -e "Middleware Agent installation completed successfully.\n"
 if [ "${MW_ENABLE_INJECTOR}" = true ]; then
   if ! (
     if [ -z "${OTEL_INJECTOR_VERSION}" ]; then
-      log_error "Could not determine the OpenTelemetry Injector version to install."
+      echo "Error: Could not determine the OpenTelemetry Injector version to install."
       exit 1
     fi
 
-    log_info "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION}..."
+    echo -e "Installing OpenTelemetry Injector version ${OTEL_INJECTOR_VERSION} ...\n"
 
     # Map uname -m arch to the arch string used in injector release filenames
     OTEL_INJECTOR_ARCH=""
@@ -324,7 +335,7 @@ if [ "${MW_ENABLE_INJECTOR}" = true ]; then
     elif [[ $MW_DETECTED_ARCH == "x86_64" ]]; then
       OTEL_INJECTOR_ARCH="x86_64"
     else
-      log_warn "Unsupported architecture '${MW_DETECTED_ARCH}' for OTel Injector. Skipping."
+      echo "Warning: Unsupported architecture '${MW_DETECTED_ARCH}' for OTel Injector. Skipping."
       exit 1
     fi
 
@@ -335,27 +346,26 @@ if [ "${MW_ENABLE_INJECTOR}" = true ]; then
     OTEL_INJECTOR_URL="https://github.com/${OTEL_INJECTOR_REPO}/releases/download/${OTEL_INJECTOR_VERSION}/${OTEL_INJECTOR_RPM}"
     OTEL_INJECTOR_TMP="/tmp/${OTEL_INJECTOR_RPM}"
 
-    log_info "Downloading ${OTEL_INJECTOR_URL}..."
+    echo "Downloading ${OTEL_INJECTOR_URL} ..."
     if ! curl -fSL -o "$OTEL_INJECTOR_TMP" "$OTEL_INJECTOR_URL"; then
-      log_error "Failed to download OpenTelemetry Injector package."
-      log_error "URL: ${OTEL_INJECTOR_URL}"
+      echo "Error: Failed to download OpenTelemetry Injector package."
+      echo "URL: ${OTEL_INJECTOR_URL}"
       rm -f "$OTEL_INJECTOR_TMP"
       exit 1
     fi
-    log_ok "Downloaded ${OTEL_INJECTOR_RPM}."
+    echo "Downloaded ${OTEL_INJECTOR_RPM}."
 
-    log_info "Installing OpenTelemetry Injector package..."
+    echo "Installing OpenTelemetry Injector package ..."
     if ! sudo rpm -U --replacepkgs "$OTEL_INJECTOR_TMP"; then
-      log_error "Failed to install OpenTelemetry Injector package."
+      echo "Error: Failed to install OpenTelemetry Injector package."
       rm -f "$OTEL_INJECTOR_TMP"
       exit 1
     fi
 
     rm -f "$OTEL_INJECTOR_TMP"
 
-    log_ok "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully."
+    echo -e "OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} installed successfully.\n"
 
-    echo ""
     echo "================================================================="
     echo "  OpenTelemetry Injector ${OTEL_INJECTOR_VERSION} (${MW_DETECTED_ARCH}) installed successfully"
     echo "================================================================="
@@ -364,7 +374,7 @@ if [ "${MW_ENABLE_INJECTOR}" = true ]; then
     echo "  Version:       ${OTEL_INJECTOR_VERSION}"
     echo ""
   ); then
-    log_warn "OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected."
+    echo -e "Warning: OpenTelemetry Injector installation did not complete; continuing without it. Core agent monitoring is unaffected.\n"
   fi
 else
   echo -e "OTel Injector installation skipped (MW_ENABLE_INJECTOR=${MW_ENABLE_INJECTOR}).\n"

--- a/scripts/rpm-install.sh
+++ b/scripts/rpm-install.sh
@@ -153,6 +153,7 @@ echo -e "\nInstalling Middleware Agent version ${MW_VERSION} on hostname $(hostn
 
 # Check if /etc/os-release file exists
 if [ -f /etc/os-release ]; then
+  # shellcheck source=/dev/null
   source /etc/os-release
   case "$ID" in
     rhel|centos|fedora|almalinux|rocky|amzn|ol|sles|azurelinux)


### PR DESCRIPTION
The opentelemetry-packaging repo is the new home for the injector's
DEB/RPM packages, but it currently ships only a pre-release (v0.0.2),
which GitHub's /releases/latest excludes. Rather than auto-installing an
unvetted pre-release, resolve the version as:

  - no pin: prefer the latest STABLE from opentelemetry-packaging; while
    none exists, fall back to the last known-good stable v0.9.2 from the
    legacy opentelemetry-injector repo
  - user-pinned OTEL_INJECTOR_VERSION: fetched from the legacy repo

Version and repo are now resolved together so the download always points
at the repo that actually hosts the chosen version.

Also replace the undefined log_* helper calls in the injector block with
echo (the helpers live on the unified-logging branch, not this one),
fixing the "log_error: command not found" runtime failure.